### PR TITLE
remove "wixads" from block list

### DIFF
--- a/easylist/easylist_general_block.txt
+++ b/easylist/easylist_general_block.txt
@@ -6210,9 +6210,6 @@
 /wipeads/*
 /wire/ads/*
 /wired/ads/*
-/wix-ad.
-/wixads.
-/wixads/*
 /wlbetathome/bannerflow/*
 /wmads.
 /wordpress-ads-plug-in/*


### PR DESCRIPTION
Hi there, These "ads" are simple logos on wix websites. They are non-intrusive, and only appear on free websites. They simply promote a business management platform, and aren't related to any click/view revenues.

Thanks